### PR TITLE
Refactor linklist to use more efficient selectors

### DIFF
--- a/src/htdocs/css/linklist.scss
+++ b/src/htdocs/css/linklist.scss
@@ -2,45 +2,64 @@
 
 @import 'variables';
 
+
+.linklist-header {
+  text-decoration: underline;
+  color: $link-color;
+  margin: 0 0 -.25rem 0;
+  padding: 0;
+  line-height: 1.4;
+  font-size: 1.125em;
+
+  &:active {
+    color: $link-color-active;
+  }
+}
+
+.linklist-image {
+  float: left;
+  margin: 2rem $horizontal-spacing 0 0;
+}
+
+.linklist-content {
+  color: $body-text-color;
+}
+
+.linklist-item {
+  text-decoration: none;
+  padding: 2.5rem 0;
+  display: inline-block;
+  overflow: auto;
+
+  > h2,
+  > h3,
+  > h4 {
+    @extend .linklist-header;
+  }
+
+  > p {
+    @extend .linklist-content;
+  }
+
+  > img {
+    @extend .linklist-image;
+  }
+}
+
 .linklist {
-	list-style: none;
-	padding: 0;
-	margin: 0;
+  list-style: none;
+  padding: 0;
+  margin: 0;
 
-	> li {
-		border-top: 1px dotted #ddd;
+  > li {
+    border-top: 1px dotted #ddd;
 
-		&:first-child {
-			border: none;
-		}
+    &:first-child {
+      border: none;
+    }
 
-		> a {
-			text-decoration: none;
-			padding: 2.5rem 0;
-			display: inline-block;
-			overflow: auto;
-		}
-
-		h2, h3, h4 {
-			text-decoration: underline;
-			color: $link-color;
-			margin: 0 0 -.25rem 0;
-			padding: 0;
-			line-height: 1.4;
-			font-size: 1.125em;
-
-			&:active {
-				color: $link-color-active;
-			}
-		}
-
-		p {
-			color: $body-text-color;
-		}
-
-		img {
-			float: left;
-			margin: 2rem $horizontal-spacing 0 0;
-		}
-	}
+    > a {
+      @extend .linklist-item;
+    }
+  }
 }


### PR DESCRIPTION
Food for thought, this implementation may be more efficient but requires additional classes in markup.  The markup supports either option, although leaves the overhead for all the generic elements which removes most of the benefit (I'd prefer to remove the element selectors altogether).  Removing element selectors places a little extra burden on authors to use the classes, but saves cpu cycles, battery, and load time for users.

Selectors are evaluated right to left, so if we use element selectors like `img`, every image on the page has to check whether it is inside a list item, etc.  If we marked up a linklist like this, the browser could render it by matching only class names (also threw in other elements, which could be interchangeable):

```
<ul class="linklist">
  <li><a class="linklist-item">
    <strong class="linklist-header">I'm a header</strong>
    <img class="linklist-image" src="image.png"/>
    <div class="linklist-content">I'm content</div>
  </a></li>
</ul>
```

An in-between might be only a class on the anchor, reusing other template classes for the ul, with direct descendant for header, image, content.  Thoughts?